### PR TITLE
support python3

### DIFF
--- a/imageloader.c
+++ b/imageloader.c
@@ -551,7 +551,7 @@ Image_dealloc(Image *self)
         self->original = NULL;
     }
 
-    self->ob_type->tp_free((PyObject*)self);
+    Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 /** initializer */


### PR DESCRIPTION
compile failed because `self->ob_type` is obsolete.  
change to use Py_TYPE macro(python26+)
